### PR TITLE
Travis CI OS X build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: cpp
+os:
+  - linux
+  - osx
 compiler:
   - gcc
   - clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
     - valgrind
     - libcppunit-dev
 before_install:
- - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then ls -l $(brew --prefix)/bin && brew list && brew update && brew install valgrind && HOMEBREW_CC=gcc-4.9.2 HOMEBREW_CXX=g++-4.9.2 brew install --build-from-source cppunit; fi
+ - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then brew update && brew install valgrind && HOMEBREW_CC=gcc-4.9 HOMEBREW_CXX=g++-4.9 brew install --build-from-source cppunit; fi
  - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "clang++" ]; then brew update && brew install valgrind cppunit; fi
  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Darwin-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=3; else export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Linux-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=1; fi
  - cd /tmp
@@ -27,6 +27,6 @@ before_install:
  - tar xzf cmake.tar.gz --strip-components="${CMAKE_STRIP_COMPONENTS}" --directory cmake
  - export PATH=/tmp/cmake/bin:$PATH
  - cd -
-before_script: mkdir build && cd build && if [ "${TRAVIS_OS_NAME}" = "osx" ]; then if [ "${CXX}" = "g++" ]; then export CXX=g++-4.9.2; fi else if [ "${CXX}" = "clang++" ]; then export CXX=/usr/bin/clang++-3.6; fi && if [ "${CXX}" = "g++" ]; then export CXX=/usr/bin/g++-5; fi fi
+before_script: mkdir build && cd build && if [ "${TRAVIS_OS_NAME}" = "osx" ]; then if [ "${CXX}" = "g++" ]; then export CXX=g++-4.9; fi else if [ "${CXX}" = "clang++" ]; then export CXX=/usr/bin/clang++-3.6; fi && if [ "${CXX}" = "g++" ]; then export CXX=/usr/bin/g++-5; fi fi
 script: cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGEOMETRY_BUILD_TESTS=ON -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -pedantic" .. && make && ctest --verbose -D ExperimentalMemCheck
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
     - libcppunit-dev
 before_install:
  - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then brew update && brew tap homebrew/versions && brew install gcc5; fi
- - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then brew update && brew install valgrind && HOMEBREW_CC=gcc-5 HOMEBREW_CXX=g++-5 brew install --build-from-source cppunit; fi
+ - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then brew update && brew install valgrind && HOMEBREW_CC=/usr/local/Cellar/gcc5/5.2.0/bin/gcc-5 HOMEBREW_CXX=/usr/local/Cellar/gcc5/5.2.0/bin/g++-5 brew install --build-from-source cppunit; fi
  - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "clang++" ]; then brew update && brew install valgrind cppunit; fi
  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Darwin-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=3; else export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Linux-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=1; fi
  - cd /tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
     - valgrind
     - libcppunit-dev
 before_install:
- - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew update && brew install cppunit gcc valgrind; fi
+ - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew update && brew unlink gcc && brew install cppunit gcc valgrind; fi
  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Darwin-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=3; else export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Linux-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=1; fi
  - cd /tmp
  - wget --no-check-certificate "${CMAKE_URL}" --output-document=cmake.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,9 @@ addons:
     - libcppunit-dev
     - valgrind
 before_install:
+ - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Darwin-x86_64.tar.gz"; else export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Linux-x86_64.tar.gz"; fi
  - cd /tmp
- - wget --no-check-certificate https://cmake.org/files/v3.4/cmake-3.4.1-Linux-x86_64.tar.gz --output-document=cmake.tar.gz
+ - wget --no-check-certificate "${CMAKE_URL}" --output-document=cmake.tar.gz
  - mkdir cmake
  - tar xzf cmake.tar.gz --strip-components=1 --directory cmake
  - export PATH=/tmp/cmake/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
     - valgrind
     - libcppunit-dev
 before_install:
- - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew update && brew unlink gcc && brew install cppunit gcc valgrind; fi
+ - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew update && brew switch gcc 5.3.0 && brew install cppunit valgrind; fi
  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Darwin-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=3; else export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Linux-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=1; fi
  - cd /tmp
  - wget --no-check-certificate "${CMAKE_URL}" --output-document=cmake.tar.gz
@@ -26,6 +26,6 @@ before_install:
  - tar xzf cmake.tar.gz --strip-components="${CMAKE_STRIP_COMPONENTS}" --directory cmake
  - export PATH=/tmp/cmake/bin:$PATH
  - cd -
-before_script: mkdir build && cd build && if [ "${TRAVIS_OS_NAME}" = "osx" ]; then if [ "${CXX}" = "g++" ]; then export CXX=g++-5; fi else if [ "${CXX}" = "clang++" ]; then export CXX=/usr/bin/clang++-3.6; fi && if [ "${CXX}" = "g++" ]; then export CXX=/usr/bin/g++-5; fi fi
+before_script: mkdir build && cd build && if [ "${TRAVIS_OS_NAME}" = "osx" ]; then if [ "${CXX}" = "g++" ]; then export CXX=g++-5.3.0; fi else if [ "${CXX}" = "clang++" ]; then export CXX=/usr/bin/clang++-3.6; fi && if [ "${CXX}" = "g++" ]; then export CXX=/usr/bin/g++-5; fi fi
 script: cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGEOMETRY_BUILD_TESTS=ON -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -pedantic" .. && make && ctest --verbose -D ExperimentalMemCheck
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
     - valgrind
     - libcppunit-dev
 before_install:
+ - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew update && brew install cppunit; fi
  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Darwin-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=3; else export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Linux-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=1; fi
  - cd /tmp
  - wget --no-check-certificate "${CMAKE_URL}" --output-document=cmake.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ addons:
     - valgrind
     - libcppunit-dev
 before_install:
- - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew update && brew tap homebrew/versions && brew install gcc5 && brew install cppunit valgrind; fi
+ - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew update && brew install cppunit valgrind; fi
+ - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then brew update && brew tap homebrew/versions && brew install gcc5; fi
  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Darwin-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=3; else export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Linux-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=1; fi
  - cd /tmp
  - wget --no-check-certificate "${CMAKE_URL}" --output-document=cmake.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ addons:
     - valgrind
     - libcppunit-dev
 before_install:
- - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then brew update && brew tap homebrew/versions && brew install gcc5 && brew switch gcc 5.2.0; fi
- - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then brew update && brew install valgrind && HOMEBREW_CC=gcc-5.2.0 HOMEBREW_CXX=g++-5.2.0 brew install --build-from-source cppunit; fi
+ - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then ls -l $(brew --prefix) && brew update && brew install valgrind && HOMEBREW_CC=gcc-4.9.2 HOMEBREW_CXX=g++-4.9.2 brew install --build-from-source cppunit; fi
  - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "clang++" ]; then brew update && brew install valgrind cppunit; fi
  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Darwin-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=3; else export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Linux-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=1; fi
  - cd /tmp
@@ -28,6 +27,6 @@ before_install:
  - tar xzf cmake.tar.gz --strip-components="${CMAKE_STRIP_COMPONENTS}" --directory cmake
  - export PATH=/tmp/cmake/bin:$PATH
  - cd -
-before_script: mkdir build && cd build && if [ "${TRAVIS_OS_NAME}" = "osx" ]; then if [ "${CXX}" = "g++" ]; then export CXX=g++-5; fi else if [ "${CXX}" = "clang++" ]; then export CXX=/usr/bin/clang++-3.6; fi && if [ "${CXX}" = "g++" ]; then export CXX=/usr/bin/g++-5; fi fi
+before_script: mkdir build && cd build && if [ "${TRAVIS_OS_NAME}" = "osx" ]; then if [ "${CXX}" = "g++" ]; then export CXX=g++-4.9.2; fi else if [ "${CXX}" = "clang++" ]; then export CXX=/usr/bin/clang++-3.6; fi && if [ "${CXX}" = "g++" ]; then export CXX=/usr/bin/g++-5; fi fi
 script: cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGEOMETRY_BUILD_TESTS=ON -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -pedantic" .. && make && ctest --verbose -D ExperimentalMemCheck
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ addons:
     - valgrind
     - libcppunit-dev
 before_install:
- - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then brew update && brew tap homebrew/versions && brew install gcc5; fi
- - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then brew update && brew install valgrind && HOMEBREW_CC=/usr/local/Cellar/gcc5/5.2.0/bin/gcc-5 HOMEBREW_CXX=/usr/local/Cellar/gcc5/5.2.0/bin/g++-5 brew install --build-from-source cppunit; fi
+ - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then brew update && brew tap homebrew/versions && brew install gcc5 && export PATH=/usr/local/Cellar/gcc5/5.2.0/bin:$PATH; fi
+ - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then brew update && brew install valgrind && HOMEBREW_CC=gcc-5 HOMEBREW_CXX=g++-5 brew install --build-from-source cppunit; fi
  - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "clang++" ]; then brew update && brew install valgrind cppunit; fi
  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Darwin-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=3; else export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Linux-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=1; fi
  - cd /tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
     - valgrind
     - libcppunit-dev
 before_install:
- - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew update && brew install cppunit && brew install valgrind; fi
+ - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew update && brew install cppunit gcc valgrind; fi
  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Darwin-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=3; else export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Linux-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=1; fi
  - cd /tmp
  - wget --no-check-certificate "${CMAKE_URL}" --output-document=cmake.tar.gz
@@ -25,6 +25,6 @@ before_install:
  - tar xzf cmake.tar.gz --strip-components="${CMAKE_STRIP_COMPONENTS}" --directory cmake
  - export PATH=/tmp/cmake/bin:$PATH
  - cd -
-before_script: mkdir build && cd build && if [ "${TRAVIS_OS_NAME}" = "osx" ]; then if [ "${CXX}" = "g++" ]; then export CXX=gcc-4.8; fi else if [ "${CXX}" = "clang++" ]; then export CXX=/usr/bin/clang++-3.6; fi && if [ "${CXX}" = "g++" ]; then export CXX=/usr/bin/g++-5; fi fi
+before_script: mkdir build && cd build && if [ "${TRAVIS_OS_NAME}" = "osx" ]; then if [ "${CXX}" = "g++" ]; then export CXX=g++-5; fi else if [ "${CXX}" = "clang++" ]; then export CXX=/usr/bin/clang++-3.6; fi && if [ "${CXX}" = "g++" ]; then export CXX=/usr/bin/g++-5; fi fi
 script: cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGEOMETRY_BUILD_TESTS=ON -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -pedantic" .. && make && ctest --verbose -D ExperimentalMemCheck
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ addons:
     - valgrind
 before_install:
  - cd /tmp
- - wget --no-check-certificate https://cmake.org/files/v3.4/cmake-3.4.1.tar.gz
- - tar xzf cmake-3.4.1.tar.gz
+ - wget --no-check-certificate https://cmake.org/files/v3.4/cmake-3.4.1-Linux-x86_64.tar.gz
+ - tar xzf cmake-3.4.1-Linux-x86_64.tar.gz
  - export PATH=/tmp/cmake-3.4.1-Linux-x86_64/bin:$PATH
  - cd -
 before_script: mkdir build && cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ addons:
     - valgrind
 before_install:
  - cd /tmp
- - wget http://www.cmake.org/files/v3.3/cmake-3.3.0-Linux-x86_64.tar.gz
- - tar xzf cmake-3.3.0-Linux-x86_64.tar.gz
- - export PATH=/tmp/cmake-3.3.0-Linux-x86_64/bin:$PATH
+ - wget https://cmake.org/files/v3.4/cmake-3.4.1.tar.gz
+ - tar xzf cmake-3.4.1.tar.gz
+ - export PATH=/tmp/cmake-3.4.1-Linux-x86_64/bin:$PATH
  - cd -
 before_script: mkdir build && cd build
 script: cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGEOMETRY_BUILD_TESTS=ON -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -pedantic" .. && make && ctest --verbose -D ExperimentalMemCheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
     - valgrind
     - libcppunit-dev
 before_install:
- - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then ls -l $(brew --prefix) && brew update && brew install valgrind && HOMEBREW_CC=gcc-4.9.2 HOMEBREW_CXX=g++-4.9.2 brew install --build-from-source cppunit; fi
+ - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then ls -l $(brew --prefix)/bin && brew list && brew update && brew install valgrind && HOMEBREW_CC=gcc-4.9.2 HOMEBREW_CXX=g++-4.9.2 brew install --build-from-source cppunit; fi
  - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "clang++" ]; then brew update && brew install valgrind cppunit; fi
  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Darwin-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=3; else export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Linux-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=1; fi
  - cd /tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ addons:
     - libcppunit-dev
     - valgrind
 before_install:
- - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Darwin-x86_64.tar.gz"; else export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Linux-x86_64.tar.gz"; fi
+ - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Darwin-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=3; else export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Linux-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=1; fi
  - cd /tmp
  - wget --no-check-certificate "${CMAKE_URL}" --output-document=cmake.tar.gz
  - mkdir cmake
- - tar xzf cmake.tar.gz --strip-components=1 --directory cmake
+ - tar xzf cmake.tar.gz --strip-components="${CMAKE_STRIP_COMPONENTS}" --directory cmake
  - export PATH=/tmp/cmake/bin:$PATH
  - cd -
 before_script: mkdir build && cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
 compiler:
   - gcc
   - clang
+osx_image: xcode7.2
 sudo: false
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
     - valgrind
     - libcppunit-dev
 before_install:
- - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew update && brew install cppunit; fi
+ - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew update && brew install cppunit && brew install valgrind; fi
  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Darwin-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=3; else export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Linux-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=1; fi
  - cd /tmp
  - wget --no-check-certificate "${CMAKE_URL}" --output-document=cmake.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
     - valgrind
     - libcppunit-dev
 before_install:
- - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew update && brew switch gcc 5.3.0 && brew install cppunit valgrind; fi
+ - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew update && brew tap homebrew/versions && brew install gcc5 && brew install cppunit valgrind; fi
  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Darwin-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=3; else export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Linux-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=1; fi
  - cd /tmp
  - wget --no-check-certificate "${CMAKE_URL}" --output-document=cmake.tar.gz
@@ -26,6 +26,6 @@ before_install:
  - tar xzf cmake.tar.gz --strip-components="${CMAKE_STRIP_COMPONENTS}" --directory cmake
  - export PATH=/tmp/cmake/bin:$PATH
  - cd -
-before_script: mkdir build && cd build && if [ "${TRAVIS_OS_NAME}" = "osx" ]; then if [ "${CXX}" = "g++" ]; then export CXX=g++-5.3.0; fi else if [ "${CXX}" = "clang++" ]; then export CXX=/usr/bin/clang++-3.6; fi && if [ "${CXX}" = "g++" ]; then export CXX=/usr/bin/g++-5; fi fi
+before_script: mkdir build && cd build && if [ "${TRAVIS_OS_NAME}" = "osx" ]; then if [ "${CXX}" = "g++" ]; then export CXX=g++-5.2.0; fi else if [ "${CXX}" = "clang++" ]; then export CXX=/usr/bin/clang++-3.6; fi && if [ "${CXX}" = "g++" ]; then export CXX=/usr/bin/g++-5; fi fi
 script: cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGEOMETRY_BUILD_TESTS=ON -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -pedantic" .. && make && ctest --verbose -D ExperimentalMemCheck
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ addons:
     - valgrind
     - libcppunit-dev
 before_install:
- - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew update && brew install cppunit valgrind; fi
  - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then brew update && brew tap homebrew/versions && brew install gcc5; fi
+ - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew update && brew install valgrind && brew install --build-from-source cppunit; fi
  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Darwin-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=3; else export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Linux-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=1; fi
  - cd /tmp
  - wget --no-check-certificate "${CMAKE_URL}" --output-document=cmake.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ addons:
     - valgrind
     - libcppunit-dev
 before_install:
- - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then brew update && brew tap homebrew/versions && brew install gcc5; fi
- - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then brew update && brew install valgrind && brew install --build-from-source --cc=gcc-5 --cxx=g++-5 cppunit; fi
+ - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then brew update && brew tap homebrew/versions && brew install gcc5 && brew switch gcc 5.2.0; fi
+ - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then brew update && brew install valgrind && HOMEBREW_CC=gcc-5.2.0 HOMEBREW_CXX=g++-5.2.0 brew install --build-from-source cppunit; fi
  - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "clang++" ]; then brew update && brew install valgrind cppunit; fi
  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Darwin-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=3; else export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Linux-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=1; fi
  - cd /tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,6 @@ before_install:
  - tar xzf cmake.tar.gz --strip-components="${CMAKE_STRIP_COMPONENTS}" --directory cmake
  - export PATH=/tmp/cmake/bin:$PATH
  - cd -
-before_script: mkdir build && cd build && if [ "${TRAVIS_OS_NAME}" = "osx" ]; then if [ "${CXX}" = "g++" ]; then export CXX=g++-5.2.0; fi else if [ "${CXX}" = "clang++" ]; then export CXX=/usr/bin/clang++-3.6; fi && if [ "${CXX}" = "g++" ]; then export CXX=/usr/bin/g++-5; fi fi
+before_script: mkdir build && cd build && if [ "${TRAVIS_OS_NAME}" = "osx" ]; then if [ "${CXX}" = "g++" ]; then export CXX=g++-5; fi else if [ "${CXX}" = "clang++" ]; then export CXX=/usr/bin/clang++-3.6; fi && if [ "${CXX}" = "g++" ]; then export CXX=/usr/bin/g++-5; fi fi
 script: cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGEOMETRY_BUILD_TESTS=ON -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -pedantic" .. && make && ctest --verbose -D ExperimentalMemCheck
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ addons:
     - valgrind
     - libcppunit-dev
 before_install:
- - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then brew update && brew tap homebrew/versions && brew install gcc5 && ln -s /usr/local/Cellar/gcc5/5.2.0/bin/gcc-5 $(brew --prefix)/bin/gcc-5 && ln -s /usr/local/Cellar/gcc5/5.2.0/g++-5 $(brew --prefix)/bin/g++-5; fi
- - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then brew update && brew install valgrind && HOMEBREW_CC=gcc-5 HOMEBREW_CXX=g++-5 brew install --build-from-source cppunit; fi
+ - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then brew update && brew tap homebrew/versions && brew install gcc5; fi
+ - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then brew update && brew install valgrind && brew install --build-from-source --cc=gcc-5 --cxx=g++-5 cppunit; fi
  - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "clang++" ]; then brew update && brew install valgrind cppunit; fi
  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Darwin-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=3; else export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Linux-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=1; fi
  - cd /tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
     - valgrind
     - libcppunit-dev
 before_install:
- - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then brew update && brew tap homebrew/versions && brew install gcc5 && export PATH=/usr/local/Cellar/gcc5/5.2.0/bin:$PATH; fi
+ - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then brew update && brew tap homebrew/versions && brew install gcc5 && ln -s /usr/local/Cellar/gcc5/5.2.0/bin/gcc-5 $(brew --prefix)/bin/gcc-5 && ln -s /usr/local/Cellar/gcc5/5.2.0/g++-5 $(brew --prefix)/bin/g++-5; fi
  - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then brew update && brew install valgrind && HOMEBREW_CC=gcc-5 HOMEBREW_CXX=g++-5 brew install --build-from-source cppunit; fi
  - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "clang++" ]; then brew update && brew install valgrind cppunit; fi
  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Darwin-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=3; else export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Linux-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=1; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ addons:
     - libcppunit-dev
 before_install:
  - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then brew update && brew tap homebrew/versions && brew install gcc5; fi
- - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew update && brew install valgrind && brew install --build-from-source cppunit; fi
+ - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "g++" ]; then brew update && brew install valgrind && HOMEBREW_CC=gcc-5 HOMEBREW_CXX=g++-5 brew install --build-from-source cppunit; fi
+ - if [ "${TRAVIS_OS_NAME}" = "osx" ] && [ "${CXX}" = "clang++" ]; then brew update && brew install valgrind cppunit; fi
  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Darwin-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=3; else export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Linux-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=1; fi
  - cd /tmp
  - wget --no-check-certificate "${CMAKE_URL}" --output-document=cmake.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,10 @@ addons:
     - valgrind
 before_install:
  - cd /tmp
- - wget --no-check-certificate https://cmake.org/files/v3.4/cmake-3.4.1-Linux-x86_64.tar.gz
- - tar xzf cmake-3.4.1-Linux-x86_64.tar.gz
- - export PATH=/tmp/cmake-3.4.1-Linux-x86_64/bin:$PATH
+ - wget --no-check-certificate https://cmake.org/files/v3.4/cmake-3.4.1-Linux-x86_64.tar.gz --output-document=cmake.tar.gz
+ - mkdir cmake
+ - tar xzf cmake.tar.gz --strip-components=1 --directory cmake
+ - export PATH=/tmp/cmake/bin:$PATH
  - cd -
 before_script: mkdir build && cd build
 script: cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGEOMETRY_BUILD_TESTS=ON -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -pedantic" .. && make && ctest --verbose -D ExperimentalMemCheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,22 @@ compiler:
 sudo: false
 addons:
   apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    - llvm-toolchain-precise-3.6
     packages:
-    - libcppunit-dev
+    - g++-5
+    - clang-3.6
     - valgrind
+    - libcppunit-dev
 before_install:
- - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Darwin-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=3; else export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Linux-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=1; fi
+ - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Darwin-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=3; else export CMAKE_URL="https://cmake.org/files/v3.4/cmake-3.4.1-Linux-x86_64.tar.gz"; export CMAKE_STRIP_COMPONENTS=1; fi
  - cd /tmp
  - wget --no-check-certificate "${CMAKE_URL}" --output-document=cmake.tar.gz
  - mkdir cmake
  - tar xzf cmake.tar.gz --strip-components="${CMAKE_STRIP_COMPONENTS}" --directory cmake
  - export PATH=/tmp/cmake/bin:$PATH
  - cd -
-before_script: mkdir build && cd build
+before_script: mkdir build && cd build && if [ "${TRAVIS_OS_NAME}" = "osx" ]; then if [ "${CXX}" = "g++" ]; then export CXX=gcc-4.8; fi else if [ "${CXX}" = "clang++" ]; then export CXX=/usr/bin/clang++-3.6; fi && if [ "${CXX}" = "g++" ]; then export CXX=/usr/bin/g++-5; fi fi
 script: cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGEOMETRY_BUILD_TESTS=ON -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -pedantic" .. && make && ctest --verbose -D ExperimentalMemCheck
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
     - valgrind
 before_install:
  - cd /tmp
- - wget https://cmake.org/files/v3.4/cmake-3.4.1.tar.gz
+ - wget --no-check-certificate https://cmake.org/files/v3.4/cmake-3.4.1.tar.gz
  - tar xzf cmake-3.4.1.tar.gz
  - export PATH=/tmp/cmake-3.4.1-Linux-x86_64/bin:$PATH
  - cd -


### PR DESCRIPTION
Extend Travis CI configuration script to additionally perform a build using g++ and clang++ on OS X.